### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#GTAppMenuController
+# GTAppMenuController
 
 This is a simple project inspired by **Paper** application of Facebook.
 
@@ -32,10 +32,10 @@ It just needs some help from you guys. After that, here's my list:
 - When select a UITableViewCell push to other View (like Paper)
 - Testing
 
-##Contributors
+## Contributors
 -  [priore](https://github.com/priore)
 
-##Contacts
+## Contacts
 
 Gianluca Tursi
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
